### PR TITLE
Remove rustc-serialize dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ license = "MIT"
 
 [dependencies]
 clap = "2.21.1"
-rustc-serialize = "0.3.23"


### PR DESCRIPTION
rustc-serialize is deprecated and unused.